### PR TITLE
feat: add recurrence columns to agenda_calendar_events

### DIFF
--- a/src/Database/Filters/CalendarEventsQueryFilter.php
+++ b/src/Database/Filters/CalendarEventsQueryFilter.php
@@ -177,13 +177,74 @@ class CalendarEventsQueryFilter extends AbstractQueryFilter
         }
     }
 
-    public function externalEventId($value)
-    {
-            $externalEvent = \NextDeveloper\\Database\Models\ExternalEvents::where('uuid', $value)->first();
 
-        if($externalEvent) {
-            return $this->builder->where('external_event_id', '=', $externalEvent->id);
+    public function rrule($value)
+    {
+        return $this->builder->where('rrule', 'like', '%' . $value . '%');
+    }
+
+    public function cronExpression($value)
+    {
+        return $this->builder->where('cron_expression', 'like', '%' . $value . '%');
+    }
+
+    public function yearlyNotificationCron($value)
+    {
+        return $this->builder->where('yearly_notification_cron', 'like', '%' . $value . '%');
+    }
+
+    public function frequency($value)
+    {
+        return $this->builder->where('frequency', 'like', '%' . $value . '%');
+    }
+
+    public function frequencyVariant($value)
+    {
+        return $this->builder->where('frequency_variant', 'like', '%' . $value . '%');
+    }
+
+    public function repeatInterval($value)
+    {
+        $operator = substr($value, 0, 1);
+
+        if ($operator != '<' || $operator != '>') {
+            $operator = '=';
+        } else {
+            $value = substr($value, 1);
         }
+
+        return $this->builder->where('repeat_interval', $operator, $value);
+    }
+
+    public function occurrenceCount($value)
+    {
+        $operator = substr($value, 0, 1);
+
+        if ($operator != '<' || $operator != '>') {
+            $operator = '=';
+        } else {
+            $value = substr($value, 1);
+        }
+
+        return $this->builder->where('occurrence_count', $operator, $value);
+    }
+
+    public function isInfinite($value)
+    {
+        if(!is_bool($value)) {
+            $value = false;
+        }
+
+        return $this->builder->where('is_infinite', $value);
+    }
+
+    public function isRepeat($value)
+    {
+        if(!is_bool($value)) {
+            $value = false;
+        }
+
+        return $this->builder->where('is_repeat', $value);
     }
 
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE

--- a/src/Database/Models/CalendarEvents.php
+++ b/src/Database/Models/CalendarEvents.php
@@ -38,6 +38,16 @@ use NextDeveloper\Commons\Database\Traits\Taggable;
  * @property string $meeting_link
  * @property $data
  * @property string $external_event_id
+ * @property string $rrule
+ * @property  $rrule_options
+ * @property string $cron_expression
+ * @property string $yearly_notification_cron
+ * @property string $frequency
+ * @property string $frequency_variant
+ * @property integer $repeat_interval
+ * @property integer $occurrence_count
+ * @property boolean $is_infinite
+ * @property boolean $is_repeat
  */
 class CalendarEvents extends Model
 {
@@ -75,6 +85,16 @@ class CalendarEvents extends Model
             'meeting_link',
             'data',
             'external_event_id',
+            'rrule',
+            'rrule_options',
+            'cron_expression',
+            'yearly_notification_cron',
+            'frequency',
+            'frequency_variant',
+            'repeat_interval',
+            'occurrence_count',
+            'is_infinite',
+            'is_repeat',
     ];
 
     /**
@@ -117,6 +137,16 @@ class CalendarEvents extends Model
     'meeting_link' => 'string',
     'data' => 'array',
     'external_event_id' => 'string',
+    'rrule' => 'string',
+    'rrule_options' => 'array',
+    'cron_expression' => 'string',
+    'yearly_notification_cron' => 'string',
+    'frequency' => 'string',
+    'frequency_variant' => 'string',
+    'repeat_interval' => 'integer',
+    'occurrence_count' => 'integer',
+    'is_infinite' => 'boolean',
+    'is_repeat' => 'boolean',
     ];
 
     /**

--- a/src/Http/Requests/CalendarEvents/CalendarEventsCreateRequest.php
+++ b/src/Http/Requests/CalendarEvents/CalendarEventsCreateRequest.php
@@ -29,6 +29,16 @@ class CalendarEventsCreateRequest extends AbstractFormRequest
         'meeting_link' => 'nullable|string',
         'data' => 'nullable',
         'external_event_id' => 'nullable|string|exists:external_events,uuid|uuid',
+        'rrule' => 'nullable|string',
+        'rrule_options' => 'nullable',
+        'cron_expression' => 'nullable|string',
+        'yearly_notification_cron' => 'nullable|string',
+        'frequency' => 'nullable|string|in:yearly,monthly,weekly,daily,hourly',
+        'frequency_variant' => 'nullable|string',
+        'repeat_interval' => 'nullable|integer',
+        'occurrence_count' => 'nullable|integer',
+        'is_infinite' => 'boolean',
+        'is_repeat' => 'boolean',
         ];
     }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE

--- a/src/Http/Requests/CalendarEvents/CalendarEventsUpdateRequest.php
+++ b/src/Http/Requests/CalendarEvents/CalendarEventsUpdateRequest.php
@@ -29,6 +29,16 @@ class CalendarEventsUpdateRequest extends AbstractFormRequest
         'meeting_link' => 'nullable|string',
         'data' => 'nullable',
         'external_event_id' => 'nullable|string|exists:external_events,uuid|uuid',
+        'rrule' => 'nullable|string',
+        'rrule_options' => 'nullable',
+        'cron_expression' => 'nullable|string',
+        'yearly_notification_cron' => 'nullable|string',
+        'frequency' => 'nullable|string|in:yearly,monthly,weekly,daily,hourly',
+        'frequency_variant' => 'nullable|string',
+        'repeat_interval' => 'nullable|integer',
+        'occurrence_count' => 'nullable|integer',
+        'is_infinite' => 'boolean',
+        'is_repeat' => 'boolean',
         ];
     }
     // EDIT AFTER HERE - WARNING: ABOVE THIS LINE MAY BE REGENERATED AND YOU MAY LOSE CODE

--- a/src/Http/Transformers/AbstractTransformers/AbstractCalendarEventsTransformer.php
+++ b/src/Http/Transformers/AbstractTransformers/AbstractCalendarEventsTransformer.php
@@ -57,7 +57,6 @@ class AbstractCalendarEventsTransformer extends AbstractTransformer
                                                 $iamUserId = \NextDeveloper\IAM\Database\Models\Users::where('id', $model->iam_user_id)->first();
                                                             $iamAccountId = \NextDeveloper\IAM\Database\Models\Accounts::where('id', $model->iam_account_id)->first();
                                                             $agendaCalendarId = \NextDeveloper\Agenda\Database\Models\Calendars::where('id', $model->agenda_calendar_id)->first();
-                                                            $externalEventId = \NextDeveloper\\Database\Models\ExternalEvents::where('id', $model->external_event_id)->first();
                         
         return $this->buildPayload(
             [
@@ -82,7 +81,17 @@ class AbstractCalendarEventsTransformer extends AbstractTransformer
             'status'  =>  $model->status,
             'meeting_link'  =>  $model->meeting_link,
             'data'  =>  $model->data,
-            'external_event_id'  =>  $externalEventId ? $externalEventId->uuid : null,
+            'external_event_id'  =>  $model->external_event_id,
+            'rrule'  =>  $model->rrule,
+            'rrule_options'  =>  $model->rrule_options,
+            'cron_expression'  =>  $model->cron_expression,
+            'yearly_notification_cron'  =>  $model->yearly_notification_cron,
+            'frequency'  =>  $model->frequency,
+            'frequency_variant'  =>  $model->frequency_variant,
+            'repeat_interval'  =>  $model->repeat_interval,
+            'occurrence_count'  =>  $model->occurrence_count,
+            'is_infinite'  =>  $model->is_infinite,
+            'is_repeat'  =>  $model->is_repeat,
             ]
         );
     }


### PR DESCRIPTION
## What

Makes `agenda_calendar_events` able to describe a **recurring** event. Until now a calendar event was always a single occurrence, so a repeating schedule had to be stored as one row per occurrence.

| column | meaning |
|---|---|
| `rrule` | RFC 5545 rule (`FREQ`, `INTERVAL`, `COUNT`, `UNTIL`, `BYDAY`, `BYMONTHDAY`, `BYSETPOS`, `BYMONTH`). `NULL` = single event |
| `rrule_options` | raw rule options as configured (json) |
| `cron_expression` | 6-field cron equivalent, evaluated in the event's `timezone` |
| `yearly_notification_cron` | cron for the reminder preceding a yearly occurrence |
| `frequency` | `yearly` / `monthly` / `weekly` / `daily` / `hourly` |
| `frequency_variant` | `monthly-date` / `monthly-byday` / `yearly-byday` |
| `repeat_interval` | RRULE `INTERVAL` |
| `occurrence_count` | RRULE `COUNT`, `NULL` when unbounded |
| `is_infinite` | rule has neither `COUNT` nor `UNTIL` |
| `is_repeat` | the occurrence itself repeats |

Updated by hand (not via the generator): model `@property` / `$fillable` / `$casts`, query filter, create + update requests, transformer.

`frequency` is constrained in the database and validated with `in:` on both requests. `rrule_options` is json so it gets no query filter, consistent with `data` and `guests`.

## Also fixes two pre-existing fatal errors

`CalendarEventsQueryFilter` and `AbstractCalendarEventsTransformer` **do not parse on `dev` today**:

```
PHP Parse error: syntax error, unexpected token "\" ... CalendarEventsQueryFilter.php on line 182
PHP Parse error: syntax error, unexpected token "\" ... AbstractCalendarEventsTransformer.php on line 60
```

The generator treated the plain text column `external_event_id` as a foreign key and emitted `\NextDeveloper\\Database\Models\ExternalEvents` — an invalid class reference — and emitted `externalEventId()` twice in the filter. Both classes were fatal on load, so filtering and serialising calendar events could not work at all. Since this PR edits exactly those two files, they are repaired here: `external_event_id` is filtered as text and returned as its own value.

The same generator bug affects roughly 70 other files in other modules; those are out of scope here.

## Database

The columns are **already applied** to `leo_v4`. This PR is the code side only.

## Verification

- `php -l` passes on every changed file (it did **not** pass on `dev` before this)
- no duplicate method names remain in the filter
- no generator run: all edits are manual, since the generator is what produced the broken references above

🤖 Generated with [Claude Code](https://claude.com/claude-code)