### PR TITLE
fix: boot models on Laravel 12+ by registering observers in booted()

### DIFF
--- a/src/Database/Models/AddressBooks.php
+++ b/src/Database/Models/AddressBooks.php
@@ -110,10 +110,23 @@ class AddressBooks extends Model
     {
         parent::boot();
 
-        //  We create and add Observer even if we wont use it.
-        parent::observe(AddressBooksObserver::class);
-
         self::registerScopes();
+    }
+
+    /**
+     * Registers the observer once the model has finished booting.
+     *
+     * Registering it inside boot() instantiates the model while it is still booting,
+     * which Laravel 12+ rejects with a LogicException.
+     *
+     * @return void
+     */
+    protected static function booted()
+    {
+        parent::booted();
+
+        //  We create and add Observer even if we wont use it.
+        static::observe(AddressBooksObserver::class);
     }
 
     public static function registerScopes()

--- a/src/Database/Models/AllContacts.php
+++ b/src/Database/Models/AllContacts.php
@@ -92,10 +92,23 @@ class AllContacts extends Model
     {
         parent::boot();
 
-        //  We create and add Observer even if we wont use it.
-        parent::observe(AllContactsObserver::class);
-
         self::registerScopes();
+    }
+
+    /**
+     * Registers the observer once the model has finished booting.
+     *
+     * Registering it inside boot() instantiates the model while it is still booting,
+     * which Laravel 12+ rejects with a LogicException.
+     *
+     * @return void
+     */
+    protected static function booted()
+    {
+        parent::booted();
+
+        //  We create and add Observer even if we wont use it.
+        static::observe(AllContactsObserver::class);
     }
 
     public static function registerScopes()

--- a/src/Database/Models/CalendarEventAttendees.php
+++ b/src/Database/Models/CalendarEventAttendees.php
@@ -119,10 +119,23 @@ class CalendarEventAttendees extends Model
     {
         parent::boot();
 
-        //  We create and add Observer even if we wont use it.
-        parent::observe(CalendarEventAttendeesObserver::class);
-
         self::registerScopes();
+    }
+
+    /**
+     * Registers the observer once the model has finished booting.
+     *
+     * Registering it inside boot() instantiates the model while it is still booting,
+     * which Laravel 12+ rejects with a LogicException.
+     *
+     * @return void
+     */
+    protected static function booted()
+    {
+        parent::booted();
+
+        //  We create and add Observer even if we wont use it.
+        static::observe(CalendarEventAttendeesObserver::class);
     }
 
     public static function registerScopes()

--- a/src/Database/Models/CalendarEvents.php
+++ b/src/Database/Models/CalendarEvents.php
@@ -181,10 +181,23 @@ class CalendarEvents extends Model
     {
         parent::boot();
 
-        //  We create and add Observer even if we wont use it.
-        parent::observe(CalendarEventsObserver::class);
-
         self::registerScopes();
+    }
+
+    /**
+     * Registers the observer once the model has finished booting.
+     *
+     * Registering it inside boot() instantiates the model while it is still booting,
+     * which Laravel 12+ rejects with a LogicException.
+     *
+     * @return void
+     */
+    protected static function booted()
+    {
+        parent::booted();
+
+        //  We create and add Observer even if we wont use it.
+        static::observe(CalendarEventsObserver::class);
     }
 
     public static function registerScopes()

--- a/src/Database/Models/CalendarItems.php
+++ b/src/Database/Models/CalendarItems.php
@@ -133,10 +133,23 @@ class CalendarItems extends Model
     {
         parent::boot();
 
-        //  We create and add Observer even if we wont use it.
-        parent::observe(CalendarItemsObserver::class);
-
         self::registerScopes();
+    }
+
+    /**
+     * Registers the observer once the model has finished booting.
+     *
+     * Registering it inside boot() instantiates the model while it is still booting,
+     * which Laravel 12+ rejects with a LogicException.
+     *
+     * @return void
+     */
+    protected static function booted()
+    {
+        parent::booted();
+
+        //  We create and add Observer even if we wont use it.
+        static::observe(CalendarItemsObserver::class);
     }
 
     public static function registerScopes()

--- a/src/Database/Models/CalendarSubscriptions.php
+++ b/src/Database/Models/CalendarSubscriptions.php
@@ -95,10 +95,23 @@ class CalendarSubscriptions extends Model
     {
         parent::boot();
 
-        //  We create and add Observer even if we wont use it.
-        parent::observe(CalendarSubscriptionsObserver::class);
-
         self::registerScopes();
+    }
+
+    /**
+     * Registers the observer once the model has finished booting.
+     *
+     * Registering it inside boot() instantiates the model while it is still booting,
+     * which Laravel 12+ rejects with a LogicException.
+     *
+     * @return void
+     */
+    protected static function booted()
+    {
+        parent::booted();
+
+        //  We create and add Observer even if we wont use it.
+        static::observe(CalendarSubscriptionsObserver::class);
     }
 
     public static function registerScopes()

--- a/src/Database/Models/Calendars.php
+++ b/src/Database/Models/Calendars.php
@@ -145,10 +145,23 @@ class Calendars extends Model
     {
         parent::boot();
 
-        //  We create and add Observer even if we wont use it.
-        parent::observe(CalendarsObserver::class);
-
         self::registerScopes();
+    }
+
+    /**
+     * Registers the observer once the model has finished booting.
+     *
+     * Registering it inside boot() instantiates the model while it is still booting,
+     * which Laravel 12+ rejects with a LogicException.
+     *
+     * @return void
+     */
+    protected static function booted()
+    {
+        parent::booted();
+
+        //  We create and add Observer even if we wont use it.
+        static::observe(CalendarsObserver::class);
     }
 
     public static function registerScopes()

--- a/src/Database/Models/Contacts.php
+++ b/src/Database/Models/Contacts.php
@@ -134,10 +134,23 @@ class Contacts extends Model
     {
         parent::boot();
 
-        //  We create and add Observer even if we wont use it.
-        parent::observe(ContactsObserver::class);
-
         self::registerScopes();
+    }
+
+    /**
+     * Registers the observer once the model has finished booting.
+     *
+     * Registering it inside boot() instantiates the model while it is still booting,
+     * which Laravel 12+ rejects with a LogicException.
+     *
+     * @return void
+     */
+    protected static function booted()
+    {
+        parent::booted();
+
+        //  We create and add Observer even if we wont use it.
+        static::observe(ContactsObserver::class);
     }
 
     public static function registerScopes()

--- a/src/Database/Models/TaskAssignees.php
+++ b/src/Database/Models/TaskAssignees.php
@@ -110,10 +110,23 @@ class TaskAssignees extends Model
     {
         parent::boot();
 
-        //  We create and add Observer even if we wont use it.
-        parent::observe(TaskAssigneesObserver::class);
-
         self::registerScopes();
+    }
+
+    /**
+     * Registers the observer once the model has finished booting.
+     *
+     * Registering it inside boot() instantiates the model while it is still booting,
+     * which Laravel 12+ rejects with a LogicException.
+     *
+     * @return void
+     */
+    protected static function booted()
+    {
+        parent::booted();
+
+        //  We create and add Observer even if we wont use it.
+        static::observe(TaskAssigneesObserver::class);
     }
 
     public static function registerScopes()

--- a/src/Database/Models/TaskItems.php
+++ b/src/Database/Models/TaskItems.php
@@ -133,10 +133,23 @@ class TaskItems extends Model
     {
         parent::boot();
 
-        //  We create and add Observer even if we wont use it.
-        parent::observe(TaskItemsObserver::class);
-
         self::registerScopes();
+    }
+
+    /**
+     * Registers the observer once the model has finished booting.
+     *
+     * Registering it inside boot() instantiates the model while it is still booting,
+     * which Laravel 12+ rejects with a LogicException.
+     *
+     * @return void
+     */
+    protected static function booted()
+    {
+        parent::booted();
+
+        //  We create and add Observer even if we wont use it.
+        static::observe(TaskItemsObserver::class);
     }
 
     public static function registerScopes()

--- a/src/Database/Models/Tasks.php
+++ b/src/Database/Models/Tasks.php
@@ -125,10 +125,23 @@ class Tasks extends Model
     {
         parent::boot();
 
-        //  We create and add Observer even if we wont use it.
-        parent::observe(TasksObserver::class);
-
         self::registerScopes();
+    }
+
+    /**
+     * Registers the observer once the model has finished booting.
+     *
+     * Registering it inside boot() instantiates the model while it is still booting,
+     * which Laravel 12+ rejects with a LogicException.
+     *
+     * @return void
+     */
+    protected static function booted()
+    {
+        parent::booted();
+
+        //  We create and add Observer even if we wont use it.
+        static::observe(TasksObserver::class);
     }
 
     public static function registerScopes()


### PR DESCRIPTION
## Problem

Every model in this module registers its observer inside `boot()`:

```php
public static function boot()
{
    parent::boot();
    parent::observe(XObserver::class);
    self::registerScopes();
}
```

`Model::observe()` does `new static`. Since Laravel 12, `bootIfNotBooted()` throws when a model is instantiated while it is still booting, so the first use of any model here fails on Laravel 12/13:

```
LogicException: The [Illuminate\Database\Eloquent\Model::bootIfNotBooted] method may not be called on model [...] while it is being booted.
```

Laravel 10 tolerated the pattern, which is why leo4 never hit it.

## Fix

- All 11 models register the observer in `booted()` instead, which Laravel runs after the model is marked booted. The hook exists since Laravel 7, so Laravel 10 behaviour is unchanged. Global scopes stay in `boot()`.

## Verification

Instantiated every model of every installed module, asserted the observer listeners are registered for each eloquent event, and ran queries, on both runtimes these packages are used from:

| runtime | result |
|---|---|
| Laravel 13.30.1 / PHP 8.5 (fixlean-api, Sail) | 111 models boot, 0 failures |
| Laravel 10.50.2 / PHP 8.4 (leo4, development database) | 96 models boot, 0 failures |

Before the change the same check failed on the first model of every module.

## Related

Same fix as nextdeveloper-nl/iam#234. The generator template `generator/resources/views/templates/database/model.blade.php` still emits the old pattern, so a regenerated model would reintroduce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)