### PR TITLE
fix: cast the bigint[] guests column with IntegerArray

### DIFF
--- a/src/Database/Models/CalendarEvents.php
+++ b/src/Database/Models/CalendarEvents.php
@@ -121,7 +121,7 @@ class CalendarEvents extends Model
     'title' => 'string',
     'description' => 'string',
     'location' => 'string',
-    'guests' => 'array:integer',
+    'guests' => \NextDeveloper\Commons\Database\Casts\IntegerArray::class,
     'starts_at' => 'datetime',
     'ends_at' => 'datetime',
     'agenda_calendar_id' => 'integer',


### PR DESCRIPTION
## Problem

`agenda_calendar_events.guests` is a PostgreSQL `bigint[]`, but `CalendarEvents` casts it with Laravel's `array:integer`.

That cast does not serialise a PHP array into a PostgreSQL array literal, so any write to the column fails:

```
SQLSTATE[22P02]: Invalid text representation: 7 ERROR: malformed array literal: "Array"
DETAIL: Array value must start with "{" or dimension information.
```

Reads are broken the same way — `array:integer` runs the value through `json_decode()`, which cannot parse `{1,2,3}`.

## Fix

Use `\NextDeveloper\Commons\Database\Casts\IntegerArray::class`, the integer counterpart of the `TextArray` cast already used for `tags` on the same model.

Depends on nextdeveloper-nl/commons#247, which fixes `IntegerArray` reading an empty `{}` back as `[0]` instead of `[]`.

## Verification

Real write against a clone of the platform schema (fixlean-api, Laravel 13, PostgreSQL):

```
cast(CalendarEvents.guests) = NextDeveloper\Commons\Database\Casts\IntegerArray
PASS  agenda raw literal guests             expected="{1,2,3}"  actual="{1,2,3}"
PASS  agenda read back guests               expected=[1,2,3]    actual=[1,2,3]  types=integer,integer,integer
PASS  agenda empty guests reads back as []  expected=[]         actual=[]
```

## Not changed: `CalendarItems`

`CalendarItems` casts `guests` the same way, but its table `agenda_calendar_items` does not exist — not in the platform database (`leo_v4`), not in the schema clone, and not in any migration in this repository. The model is only referenced by `AgendaAdminRole` and `AgendaUserRole`. Since the column type cannot be confirmed, the cast was left alone; the model looks like dead code and probably wants a separate decision. (It also carries an unused `Tpetry\PostgresqlEnhanced\Eloquent\Casts\IntegerArrayCast` import.)

The same `array:integer` mistake was found and fixed in three other repositories: nextdeveloper-nl/support, nextdeveloper-nl/events and nextdeveloper-nl/Intelligence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)